### PR TITLE
feat: Add API key to environment variable and add it to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+sendgrid.env


### PR DESCRIPTION
This commit adds the API key to the environment variable, allowing it to be securely stored outside the source code. Additionally, the commit includes the necessary changes to the .gitignore file to ensure that the API key is not tracked and committed to the repository. By ignoring the API key file, we protect sensitive information from being exposed in the version control history.